### PR TITLE
Use built-in JSON.stringify instead of hand-rolled function

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,10 @@ module.exports = function(options = {}) {
             val = p1;
           }
 
+          if (typeof val === 'function') {
+            return val + '';
+          }
+
           return JSON.stringify(val);
         }
 

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = function(options = {}) {
             val = p1;
           }
 
-          return '"' + val + '"';
+          return JSON.stringify(val);
         }
 
         return scan(dict);


### PR DESCRIPTION
This also allows non-string objects as values – for example, a list of strings, but also functions.

You could argue that allowing functions is a security hazard but it would seem that sanitizing the input belongs to a different layer.