### PR TITLE
Fix false positives on missing translations

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,12 +15,13 @@ module.exports = function(options = {}) {
             val = obj[p1];
           } else if (isObject(obj) && !obj.hasOwnProperty(p1)) {
             for (k in obj) {
-              if (obj.hasOwnProperty(k)) {
+              if (obj.hasOwnProperty(k) && isObject(obj[k])) {
                 scan(obj[k]);
               }
             }
           } else {
             val = p1;
+            console.log('Missing translation for:', p1)
           }
 
           return '"' + val + '"';


### PR DESCRIPTION
This will handle cases where the key of the object is null or undefined.
E.g. avoid crashing when you have translations like this

```
language: {
  'msg_hello': null,
  'msg_world: 'World!'
}
```